### PR TITLE
changes to participant_job.sh heredoc for freesurfer audit

### DIFF
--- a/scripts/cubic/bootstrap-freesurfer-audit.sh
+++ b/scripts/cubic/bootstrap-freesurfer-audit.sh
@@ -124,10 +124,11 @@ echo ${FS_INPUT_ZIP}
 echo ${FMRI_INPUT_ZIP}
 datalad run \
     -i code/fs_euler_checker_and_plots_simplified.py \
-    -i ${FS_INPUT_ZIP} \
-    -i ${FMRI_INPUT_ZIP} \
+    ${FS_INPUT_ZIP} \
+    ${FMRI_INPUT_ZIP} \
     --explicit \
     -o csvs \
+    -o svg \
     -m "freesurfer-audit ${subid}" \
     "python code/fs_euler_checker_and_plots_simplified.py ${subid} ${ZIPS_DIR}"
 


### PR DESCRIPTION
remove -i as -i is already included in ${FS_INPUT_ZIP} and ${FMRI_INPUT_ZIP}; add -o for one additional SVG output directory