### PR TITLE
Update bootstrap-fmriprep-multises-audit.sh

### DIFF
--- a/scripts/cubic/bootstrap-fmriprep-multises-audit.sh
+++ b/scripts/cubic/bootstrap-fmriprep-multises-audit.sh
@@ -296,7 +296,7 @@ cd concat_ds/code
 wget https://raw.githubusercontent.com/PennLINC/RBC/master/PennLINC/Generic/concatenator.py
 cd ..
 datalad save -m "added concatenator script"
-datalad run -i 'csvs/*' -o 'concat_ds/group_report.csv' --expand inputs --explicit "python code/concatenator.py concat_ds/csvs ${PROJECT_ROOT}/FMRIPREP_AUDIT.csv"
+datalad run -i 'csvs/*' -o 'concat_ds/group_report.csv' --expand inputs --explicit "python code/concatenator.py csvs ${PROJECT_ROOT}/FMRIPREP_AUDIT.csv"
 
 datalad save -m "generated report"
 # push changes


### PR DESCRIPTION
The code goes into `concat_ds/code` (L295), then comes up one directory to `concat_ds` (L297). This means when you do `datalad run`, your input path should be `csvs` not `concat_ds/csvs`